### PR TITLE
Fixed broken links in Hindi JSX documentation

### DIFF
--- a/src/content/learn/writing-markup-with-jsx.md
+++ b/src/content/learn/writing-markup-with-jsx.md
@@ -166,7 +166,7 @@ img { height: 90px }
 </>
 ```
 
-इस खाली टैग को *[React fragment](TODO)* कहा जाता है। React fragments आपको ब्राउज़र HTML ट्री में कोई निशान छोड़े बिना चीजों को ग्रुप करने देते हैं।
+इस खाली टैग को *[React fragment](https://react.dev/reference/react/Fragment)* कहा जाता है। React fragments आपको ब्राउज़र HTML ट्री में कोई निशान छोड़े बिना चीजों को ग्रुप करने देते हैं।
 
 <DeepDive>
 
@@ -211,7 +211,7 @@ JSX जावास्क्रिप्ट में बदल जाता ह
 />
 ```
 
-आप [इन सभी ऐट्रिब्यूट्स को React DOM एलिमेंट्स में पा सकते हैं](TODO). यदि आप एक गलत पाते हैं, तो चिंता न करें React संभावित सुधार के साथ एक संदेश [ब्राउज़र कंसोल](https://developer.mozilla.org/docs/Tools/Browser_Console) पर प्रिंट करेगी।
+आप [इन सभी ऐट्रिब्यूट्स को React DOM एलिमेंट्स में पा सकते हैं](https://react.dev/reference/react-dom/components/common). यदि आप एक गलत पाते हैं, तो चिंता न करें React संभावित सुधार के साथ एक संदेश [ब्राउज़र कंसोल](https://developer.mozilla.org/docs/Tools/Browser_Console) पर प्रिंट करेगी।
 
 <Pitfall>
 


### PR DESCRIPTION
### Fixed broken links in Hindi JSX documentation

I have updated two broken links in the Hindi JSX documentation that were pointing to placeholder URLs (`TODO`). The changes are as follows:

1. **React Fragment Link**:  
   - **Previous**:  
     ```markdown
     [React fragment](TODO)
     ```  
   - **Updated**:  
     ```markdown
     [React fragment](https://react.dev/reference/react/Fragment)
     ```

2. **React DOM Attributes Link**:  
   - **Previous**:  
     ```markdown
     [इन सभी ऐट्रिब्यूट्स को React DOM एलिमेंट्स में पा सकते हैं](TODO)
     ```  
   - **Updated**:  
     ```markdown
     [इन सभी ऐट्रिब्यूट्स को React DOM एलिमेंट्स में पा सकते हैं](https://react.dev/reference/react-dom/components/common)
     ```

These fixes ensure that users are directed to the correct pages for additional information.

Let me know if further changes are required. Thank you! 😊

